### PR TITLE
tree: add compact similar to urkel.

### DIFF
--- a/include/urkel.h
+++ b/include/urkel.h
@@ -118,6 +118,11 @@ URKEL_EXTERN int
 urkel_remove(urkel_t *tree, const unsigned char *key);
 
 URKEL_EXTERN int
+urkel_compact(const char *dst_prefix,
+              const char *src_prefix,
+              const unsigned char *hash);
+
+URKEL_EXTERN int
 urkel_prove(urkel_t *tree,
             unsigned char **proof_raw,
             size_t *proof_len,

--- a/src/tree.c
+++ b/src/tree.c
@@ -477,6 +477,144 @@ urkel_tree_prove(tree_db_t *tree,
 }
 
 static urkel_node_t *
+urkel_tree_compact(tree_db_t *dst, tree_db_t *src, urkel_node_t *node) {
+  switch (node->type) {
+    case URKEL_NODE_NULL: {
+      return node;
+    }
+
+    case URKEL_NODE_INTERNAL: {
+      urkel_internal_t *internal = &node->u.internal;
+      urkel_node_t *left, *right, *out;
+
+      left = urkel_tree_compact(dst, src, internal->left);
+
+      if (left == NULL)
+        return NULL;
+
+      internal->left = left;
+
+      right = urkel_tree_compact(dst, src, internal->right);
+
+      if (right == NULL)
+        return NULL;
+
+      internal->right = right;
+
+      CHECK(node->flags & URKEL_FLAG_WRITTEN);
+      node->flags ^= URKEL_FLAG_WRITTEN;
+
+      urkel_store_write_node(dst->store, node);
+
+      if (urkel_store_needs_flush(dst->store)) {
+        if (!urkel_store_flush(dst->store))
+          return NULL;
+      }
+
+      out = checked_malloc(sizeof(urkel_node_t));
+      urkel_node_hash(node);
+      urkel_node_to_hash(node, out);
+      urkel_node_destroy(node, 1);
+      return out;
+    }
+
+    case URKEL_NODE_LEAF: {
+      urkel_node_t *out;
+      unsigned char value[URKEL_VALUE_SIZE];
+      size_t size;
+
+      if (!urkel_store_retrieve(src->store, node, value, &size))
+        urkel_abort();
+
+      CHECK(node->flags & URKEL_FLAG_WRITTEN);
+      urkel_node_store(node, value, size);
+      node->flags ^= URKEL_FLAG_WRITTEN;
+      node->flags ^= URKEL_FLAG_SAVED;
+
+      urkel_store_write_value(dst->store, node);
+      urkel_store_write_node(dst->store, node);
+
+      if (urkel_store_needs_flush(dst->store)) {
+        if (!urkel_store_flush(dst->store))
+          return NULL;
+      }
+
+      out = checked_malloc(sizeof(urkel_node_t));
+      urkel_node_hash(node);
+      urkel_node_to_hash(node, out);
+      urkel_node_destroy(node, 1);
+
+      return out;
+    }
+
+    case URKEL_NODE_HASH: {
+      urkel_node_t *rn = urkel_store_resolve(src->store, node);
+
+      if (rn == NULL) {
+        urkel_abort();
+        return NULL;
+      }
+
+      urkel_node_destroy(node, 1);
+      return urkel_tree_compact(dst, src, rn);
+    }
+
+    default: {
+      urkel_abort();
+      return NULL;
+    }
+  }
+}
+
+int
+urkel_compact(const char *dst_prefix,
+              const char *src_prefix,
+              const unsigned char *hash) {
+  const unsigned char *root_hash;
+  tree_db_t *dst, *src;
+  urkel_node_t *root = NULL;
+  urkel_node_t *out = NULL;
+  int ret = 1;
+
+  dst = urkel_open(dst_prefix);
+  src = urkel_open(src_prefix);
+
+  if (hash == NULL)
+    root_hash = src->hash;
+  else
+    root_hash = hash;
+
+  root = urkel_store_get_history(src->store, root_hash);
+
+  if (root == NULL) {
+    urkel_errno = URKEL_ENOTFOUND;
+    ret = 0;
+    goto fail;
+  }
+
+  out = urkel_tree_compact(dst, src, root);
+
+  if (out == NULL) {
+    urkel_errno = URKEL_EBADWRITE;
+    ret = 0;
+    goto fail;
+  }
+
+  if (!urkel_store_commit(dst->store, out)) {
+    urkel_errno = URKEL_EBADWRITE;
+    ret = 0;
+    goto fail;
+  }
+fail:
+  if (out != NULL)
+    urkel_node_destroy(out, 1);
+
+  urkel_close(dst);
+  urkel_close(src);
+  return ret;
+}
+
+static urkel_node_t *
 urkel_tree_write(tree_db_t *tree, urkel_node_t *node) {
   switch (node->type) {
     case URKEL_NODE_NULL: {

--- a/src/tree.c
+++ b/src/tree.c
@@ -577,7 +577,16 @@ urkel_compact(const char *dst_prefix,
   int ret = 1;
 
   dst = urkel_open(dst_prefix);
+
+  if (dst == NULL)
+    return 0;
+
   src = urkel_open(src_prefix);
+
+  if (src == NULL) {
+    urkel_close(src);
+    return 0;
+  }
 
   if (hash == NULL)
     root_hash = src->hash;

--- a/test/test.c
+++ b/test/test.c
@@ -419,6 +419,8 @@ test_urkel_compact(void) {
   urkel_t *db;
   urkel_tx_t *tx;
   urkel_kv_t *kvs = urkel_kv_generate(PAIRS);
+  unsigned char pre_compact_root[32];
+  unsigned char compacted_root[32];
 
   db = urkel_open(URKEL_PATH);
 
@@ -437,16 +439,81 @@ test_urkel_compact(void) {
     urkel_tx_destroy(tx);
   }
 
+  urkel_root(db, pre_compact_root);
   urkel_close(db);
   ASSERT(urkel_compact(URKEL_TMP_PATH, URKEL_PATH, NULL));
 
   db = urkel_open(URKEL_TMP_PATH);
   ASSERT(db != NULL);
 
+  urkel_root(db, compacted_root);
+  ASSERT(urkel_memcmp(pre_compact_root, compacted_root, 32) == 0);
+
   tx = urkel_tx_create(db, NULL);
   ASSERT(tx != NULL);
 
   for (i = 0; i < PAIRS; i++) {
+    unsigned char *key = kvs[i].key;
+    unsigned char *value = kvs[i].value;
+    unsigned char result[64];
+    size_t result_len;
+
+    ASSERT(urkel_tx_has(tx, key));
+    ASSERT(urkel_tx_get(tx, result, &result_len, key));
+    ASSERT(result_len == 64);
+    ASSERT(urkel_memcmp(result, value, 64) == 0);
+  }
+
+  urkel_tx_destroy(tx);
+  urkel_close(db);
+  urkel_kv_free(kvs);
+
+  ASSERT(urkel_destroy(URKEL_PATH));
+  ASSERT(urkel_destroy(URKEL_TMP_PATH));
+}
+
+void
+test_urkel_inject_compact(void) {
+  static const size_t PAIRS = 10;
+  size_t i;
+  urkel_t *db;
+  urkel_tx_t *tx;
+  urkel_kv_t *kvs = urkel_kv_generate(PAIRS);
+  unsigned char mid_root[32];
+  unsigned char compacted_root[32];
+
+  db = urkel_open(URKEL_PATH);
+
+  ASSERT(db != NULL);
+
+  for (i = 0; i < PAIRS; i++) {
+    unsigned char *key = kvs[i].key;
+    unsigned char *value = kvs[i].value;
+    tx = urkel_tx_create(db, NULL);
+
+    ASSERT(tx != NULL);
+    ASSERT(urkel_tx_insert(tx, key, value, 64));
+    ASSERT(urkel_tx_has(tx, key));
+    ASSERT(urkel_tx_commit(tx));
+    urkel_tx_destroy(tx);
+
+    if (i == PAIRS / 2)
+      urkel_root(db, mid_root);
+  }
+
+  urkel_close(db);
+  ASSERT(urkel_compact(URKEL_TMP_PATH, URKEL_PATH, mid_root));
+
+  db = urkel_open(URKEL_TMP_PATH);
+  ASSERT(db != NULL);
+
+  urkel_root(db, compacted_root);
+  ASSERT(urkel_memcmp(mid_root, compacted_root, 32) == 0);
+
+  tx = urkel_tx_create(db, NULL);
+  ASSERT(tx != NULL);
+
+  for (i = 0; i < PAIRS / 2; i++) {
     unsigned char *key = kvs[i].key;
     unsigned char *value = kvs[i].value;
     unsigned char result[64];
@@ -474,5 +541,6 @@ main(void) {
   test_urkel_leaky_inject();
   test_urkel_max_value_size();
   test_urkel_compact();
+  test_urkel_inject_compact();
   return 0;
 }

--- a/test/test.c
+++ b/test/test.c
@@ -412,6 +412,60 @@ test_urkel_max_value_size(void) {
   ASSERT(urkel_destroy(URKEL_PATH));
 }
 
+static void
+test_urkel_compact(void) {
+  static const size_t PAIRS = 100;
+  size_t i;
+  urkel_t *db;
+  urkel_tx_t *tx;
+  urkel_kv_t *kvs = urkel_kv_generate(PAIRS);
+
+  db = urkel_open(URKEL_PATH);
+
+  ASSERT(db != NULL);
+
+  for (i = 0; i < PAIRS; i++) {
+    unsigned char *key = kvs[i].key;
+    unsigned char *value = kvs[i].value;
+    tx = urkel_tx_create(db, NULL);
+
+    ASSERT(tx != NULL);
+    ASSERT(urkel_tx_insert(tx, key, value, 64));
+    ASSERT(urkel_tx_has(tx, key));
+
+    ASSERT(urkel_tx_commit(tx));
+    urkel_tx_destroy(tx);
+  }
+
+  urkel_close(db);
+  ASSERT(urkel_compact(URKEL_TMP_PATH, URKEL_PATH, NULL));
+
+  db = urkel_open(URKEL_TMP_PATH);
+  ASSERT(db != NULL);
+
+  tx = urkel_tx_create(db, NULL);
+  ASSERT(tx != NULL);
+
+  for (i = 0; i < PAIRS; i++) {
+    unsigned char *key = kvs[i].key;
+    unsigned char *value = kvs[i].value;
+    unsigned char result[64];
+    size_t result_len;
+
+    ASSERT(urkel_tx_has(tx, key));
+    ASSERT(urkel_tx_get(tx, result, &result_len, key));
+    ASSERT(result_len == 64);
+    ASSERT(urkel_memcmp(result, value, 64) == 0);
+  }
+
+  urkel_tx_destroy(tx);
+  urkel_close(db);
+  urkel_kv_free(kvs);
+
+  ASSERT(urkel_destroy(URKEL_PATH));
+  ASSERT(urkel_destroy(URKEL_TMP_PATH));
+}
+
 int
 main(void) {
   test_memcmp();
@@ -419,5 +473,6 @@ main(void) {
   test_urkel_node_replacement();
   test_urkel_leaky_inject();
   test_urkel_max_value_size();
+  test_urkel_compact();
   return 0;
 }

--- a/test/utils.h
+++ b/test/utils.h
@@ -19,6 +19,7 @@
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
 #define URKEL_PATH "./urkel_db_test"
+#define URKEL_TMP_PATH "./urkel_db_tmp_test"
 
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 /* Avoid a GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189 */


### PR DESCRIPTION
Additional checks are necessary to make sure it is fully compatible with urkel behavior. So this will be draft until I have run integration with urkel (in https://github.com/nodech/liburkel-test)

Adds compaction ability, but does not take care of the directories for you and does not check if the destination exists or not (it could even be an existing tree)