### PR TITLE
Add urkel_stat to get basic stats about the tree.

### DIFF
--- a/include/urkel.h
+++ b/include/urkel.h
@@ -48,6 +48,11 @@ typedef struct urkel_s urkel_t;
 typedef struct urkel_tx_s urkel_tx_t;
 typedef struct urkel_iter_s urkel_iter_t;
 
+typedef struct urkel_tree_stat_s {
+  size_t files; /* Number of files in the tree (except meta). */
+  size_t size;  /* Total size of all files (except meta), in bytes. */
+} urkel_tree_stat_t;
+
 /*
  * Error Number
  */
@@ -83,6 +88,9 @@ urkel_close(urkel_t *tree);
 
 URKEL_EXTERN int
 urkel_destroy(const char *prefix);
+
+URKEL_EXTERN int
+urkel_stat(const char *prefix, urkel_tree_stat_t *stat);
 
 URKEL_EXTERN int
 urkel__corrupt(const char *prefix);

--- a/src/store.h
+++ b/src/store.h
@@ -32,6 +32,9 @@ int
 urkel_store_destroy(const char *prefix);
 
 int
+urkel_store_stat(const char *prefix, urkel_tree_stat_t *stat);
+
+int
 urkel_store__corrupt(const char *prefix);
 
 urkel_node_t *

--- a/src/tree.c
+++ b/src/tree.c
@@ -621,6 +621,16 @@ urkel_destroy(const char *prefix) {
 }
 
 int
+urkel_stat(const char *prefix, urkel_tree_stat_t *stat) {
+  if (!urkel_store_stat(prefix, stat)) {
+    urkel_errno = URKEL_ECORRUPTION;
+    return 0;
+  }
+
+  return 1;
+}
+
+int
 urkel__corrupt(const char *prefix) {
   if (!urkel_store__corrupt(prefix)) {
     urkel_errno = URKEL_EBADOPEN;


### PR DESCRIPTION
Similar to `urkel.stat` from `urkel`, it returns:
  - `files` - total number of files, not including meta/lock.
  - `size` - total size of these files, not including meta/lock.

Also defines the struct in urkel.h so users can access the fields.